### PR TITLE
Add API relationship endpoints for merchant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,9 +21,6 @@ gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 
-# Use ActiveModel has_secure_password
-gem 'bcrypt'
-
 gem 'responders'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,10 @@ group :development, :test do
   gem 'rspec-rails'
 end
 
+group :test do
+  gem 'simplecov'
+end
+
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,6 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.3)
-    bcrypt (3.1.10)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
@@ -157,7 +156,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bcrypt
   byebug
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
     coffee-script-source (1.9.1.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
+    docile (1.1.5)
     erubis (2.7.0)
     execjs (2.6.0)
     globalid (0.3.6)
@@ -131,6 +132,11 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    simplecov (0.10.0)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     sprockets (3.3.4)
       rack (~> 1.0)
     sprockets-rails (2.3.3)
@@ -165,6 +171,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  simplecov
   sqlite3
   uglifier (>= 1.3.0)
   web-console (~> 2.0)

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -1,17 +1,17 @@
 class Api::V1::CustomersController < ApplicationController
   def show
-    respond_with json: Customer.find_by(id: params[:id])
+    respond_with Customer.find_by(id: params[:id])
   end
 
   def find
-    respond_with json: Customer.find_like_by(attribute, params[attribute])
+    respond_with Customer.find_like_by(attribute, params[attribute])
   end
 
   def find_all
-    respond_with json: Customer.find_all_like_by(attribute, params[attribute])
+    respond_with Customer.find_all_like_by(attribute, params[attribute])
   end
 
   def random
-    respond_with json: Customer.random
+    respond_with Customer.random
   end
 end

--- a/app/controllers/api/v1/invoice_items_controller.rb
+++ b/app/controllers/api/v1/invoice_items_controller.rb
@@ -1,17 +1,17 @@
 class Api::V1::InvoiceItemsController < ApplicationController
   def show
-    respond_with json: InvoiceItem.find_by(id: params[:id])
+    respond_with InvoiceItem.find_by(id: params[:id])
   end
 
   def find
-    respond_with json: InvoiceItem.find_like_by(attribute, params[attribute])
+    respond_with InvoiceItem.find_like_by(attribute, params[attribute])
   end
 
   def find_all
-    respond_with json: InvoiceItem.find_all_like_by(attribute, params[attribute])
+    respond_with InvoiceItem.find_all_like_by(attribute, params[attribute])
   end
 
   def random
-    respond_with json: InvoiceItem.random
+    respond_with InvoiceItem.random
   end
 end

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -1,17 +1,17 @@
 class Api::V1::InvoicesController < ApplicationController
   def show
-    respond_with json: Invoice.find_by(id: params[:id])
+    respond_with Invoice.find_by(id: params[:id])
   end
 
   def find
-    respond_with json: Invoice.find_like_by(attribute, params[attribute])
+    respond_with Invoice.find_like_by(attribute, params[attribute])
   end
 
   def find_all
-    respond_with json: Invoice.find_all_like_by(attribute, params[attribute])
+    respond_with Invoice.find_all_like_by(attribute, params[attribute])
   end
 
   def random
-    respond_with json: Invoice.random
+    respond_with Invoice.random
   end
 end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,17 +1,17 @@
 class Api::V1::ItemsController < ApplicationController
   def show
-    respond_with json: Item.find_by(id: params[:id])
+    respond_with Item.find_by(id: params[:id])
   end
 
   def find
-    respond_with json: Item.find_like_by(attribute, params[attribute])
+    respond_with Item.find_like_by(attribute, params[attribute])
   end
 
   def find_all
-    respond_with json: Item.find_all_like_by(attribute, params[attribute])
+    respond_with Item.find_all_like_by(attribute, params[attribute])
   end
 
   def random
-    respond_with json: Item.random
+    respond_with Item.random
   end
 end

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -1,17 +1,25 @@
 class Api::V1::MerchantsController < ApplicationController
   def show
-    respond_with json: Merchant.find_by(id: params[:id])
+    respond_with Merchant.find_by(id: params[:id])
   end
 
   def find
-    respond_with json: Merchant.find_like_by(attribute, params[attribute])
+    respond_with Merchant.find_like_by(attribute, params[attribute])
   end
 
   def find_all
-    respond_with json: Merchant.find_all_like_by(attribute, params[attribute])
+    respond_with Merchant.find_all_like_by(attribute, params[attribute])
   end
 
   def random
-    respond_with json: Merchant.random
+    respond_with Merchant.random
+  end
+
+  def items
+    respond_with Item.where(merchant_id: params[:id])
+  end
+
+  def invoices
+    respond_with Invoice.where(merchant_id: params[:id])
   end
 end

--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -1,17 +1,17 @@
 class Api::V1::TransactionsController < ApplicationController
   def show
-    respond_with json: Transaction.find_by(id: params[:id])
+    respond_with Transaction.find_by(id: params[:id])
   end
 
   def find
-    respond_with json: Transaction.find_like_by(attribute, params[attribute])
+    respond_with Transaction.find_like_by(attribute, params[attribute])
   end
 
   def find_all
-    respond_with json: Transaction.find_all_like_by(attribute, params[attribute])
+    respond_with Transaction.find_all_like_by(attribute, params[attribute])
   end
 
   def random
-    respond_with json: Transaction.random
+    respond_with Transaction.random
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,6 @@ require "application_responder"
 
 class ApplicationController < ActionController::Base
   before_filter :set_default_request_format
-  self.responder = ApplicationResponder
   respond_to :json
 
   # Prevent CSRF attacks by raising an exception.

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,6 +1,8 @@
 class Invoice < ActiveRecord::Base
   include Finders
 
+  belongs_to :merchant
+
   def self.import(filename)
     CSV.foreach(filename, headers: true) do |row|
       invoice = find_by_id(row["id"]) || new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,8 @@
 class Item < ActiveRecord::Base
   include Finders
 
+  belongs_to :merchant
+
   def self.import(filename)
     CSV.foreach(filename, headers: true) do |row|
       item = find_by_id(row["id"]) || new

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,6 +1,9 @@
 class Merchant < ActiveRecord::Base
   include Finders
 
+  has_many :items
+  has_many :invoices
+
   def self.import(filename)
     CSV.foreach(filename, headers: true) do |row|
       merchant = find_by_id(row["id"]) || new

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
       get "merchants/find_all", to: "merchants#find_all"
       get "merchants/random", to: "merchants#random"
       resources :merchants, only: [:show]
+      get "merchants/:id/items", to: "merchants#items"
+      get "merchants/:id/invoices", to: "merchants#invoices"
     end
   end
 end

--- a/spec/controllers/api/v1/merchants_controller_spec.rb
+++ b/spec/controllers/api/v1/merchants_controller_spec.rb
@@ -1,5 +1,48 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::MerchantsController, type: :controller do
+  describe "#items" do
+    it "returns a collection of items associated with that merchant" do
+      merchant = Merchant.create(name: "Acme Corporation")
+      merchant.items.create(
+        name: "Explosive Tennis Balls",
+        description: "Tickle your friends! Surprise your opponent!",
+        unit_price: "120000")
+      merchant.items.create(
+        name: "American Wrought Anvils",
+        description: "They ring like a bell.",
+        unit_price: "10000")
+      merchant.items.create(
+        name: "Instant Tunnel",
+        description: "For a smashing good time!",
+        unit_price: "1995")
 
+      get :items, format: :json, id: merchant.id
+      items = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to have_http_status(:success)
+      expect(items.count).to eq(3)
+      items.each do |item|
+        expect(item[:merchant_id]).to eq(merchant.id)
+      end
+    end
+  end
+
+  describe "#invoices" do
+    it "returns a collection of invoices associated with that merchant" do
+      merchant = Merchant.create(name: "Acme Corporation")
+      merchant.invoices.create(status: "shipped")
+      merchant.invoices.create(status: "shipped")
+      merchant.invoices.create(status: "shipped")
+
+      get :invoices, format: :json, id: merchant.id
+      invoices = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to have_http_status(:success)
+      expect(invoices.count).to eq(3)
+      invoices.each do |invoice|
+        expect(invoice[:merchant_id]).to eq(merchant.id)
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,9 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  require 'simplecov'
+  SimpleCov.start
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
Add API relationship endpoints for merchant items and invoices.
Remove json response specification from controllers so the response is no longer wrapped in a json pointer.
Add simplecov and tests.
Remove bcrypt - not being used.
Closes #17 
